### PR TITLE
keep the key never overrides

### DIFF
--- a/lib/resty/lock.lua
+++ b/lib/resty/lock.lua
@@ -128,7 +128,7 @@ function _M.lock(self, key)
         return nil, "locked"
     end
     local exptime = self.exptime
-    local ok, err = dict:add(key, true, exptime)
+    local ok, err = dict:safe_add(key, true, exptime)
     if ok then
         cdata.key_id = ref_obj(key)
         if not shdict_mt then
@@ -154,7 +154,7 @@ function _M.lock(self, key)
         elapsed = elapsed + step
         timeout = timeout - step
 
-        local ok, err = dict:add(key, true, exptime)
+        local ok, err = dict:safe_add(key, true, exptime)
         if ok then
             cdata.key_id = ref_obj(key)
             if not shdict_mt then


### PR DESCRIPTION
never overrides the (least recently used) unexpired items in the store
when running out of storage in the shared memory zone