### PR TITLE
feature: new API expire() that can change the TTL of the lock while it

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -171,6 +171,10 @@ Sets the TTL of the lock held by the current `resty.lock` object instance. This 
 timeout of the lock to `timeout` seconds if it is given, otherwise the `timeout` provided while
 calling [new](#new) will be used.
 
+Note that the `timeout` supplied inside this function is independent from the `timeout` provided while
+calling [new](#new). Calling `expire()` will not change the `timeout` value specified inside [new](#new)
+and subsequent `expire(nil)` call will still use the `timeout` number from [new](#new).
+
 Returns `1` on success. Returns `nil` and a string describing the error otherwise.
 
 If you call `expire` when no lock is currently held, the error "unlocked" will be returned.

--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,7 @@ Table of Contents
     * [new](#new)
     * [lock](#lock)
     * [unlock](#unlock)
+    * [expire](#expire)
 * [For Multiple Lua Light Threads](#for-multiple-lua-light-threads)
 * [For Cache Locks](#for-cache-locks)
 * [Prerequisites](#prerequisites)
@@ -161,6 +162,18 @@ Releases the lock held by the current `resty.lock` object instance.
 Returns `1` on success. Returns `nil` and a string describing the error otherwise.
 
 If you call `unlock` when no lock is currently held, the error "unlocked" will be returned.
+
+expire
+------
+`syntax: ok, err = obj:expire(timeout)`
+
+Sets the TTL of the lock held by the current `resty.lock` object instance. This will reset the
+timeout of the lock to `timeout` seconds if it is given, otherwise the `timeout` provided while
+calling [new](#new) will be used.
+
+Returns `1` on success. Returns `nil` and a string describing the error otherwise.
+
+If you call `expire` when no lock is currently held, the error "unlocked" will be returned.
 
 [Back to TOC](#table-of-contents)
 

--- a/README.markdown
+++ b/README.markdown
@@ -175,7 +175,7 @@ Note that the `timeout` supplied inside this function is independent from the `t
 calling [new](#new). Calling `expire()` will not change the `timeout` value specified inside [new](#new)
 and subsequent `expire(nil)` call will still use the `timeout` number from [new](#new).
 
-Returns `1` on success. Returns `nil` and a string describing the error otherwise.
+Returns `true` on success. Returns `nil` and a string describing the error otherwise.
 
 If you call `expire` when no lock is currently held, the error "unlocked" will be returned.
 

--- a/lib/resty/lock.lua
+++ b/lib/resty/lock.lua
@@ -135,6 +135,7 @@ function _M.lock(self, key)
     local ok, err = dict:add(key, true, exptime)
     if ok then
         cdata.key_id = ref_obj(key)
+        self.key = key
         return 0
     end
     if err ~= "exists" then
@@ -154,6 +155,7 @@ function _M.lock(self, key)
         local ok, err = dict:add(key, true, exptime)
         if ok then
             cdata.key_id = ref_obj(key)
+            self.key = key
             return elapsed
         end
 
@@ -188,6 +190,27 @@ function _M.unlock(self)
         return nil, err
     end
     cdata.key_id = 0
+
+    return 1
+end
+
+
+function _M.expire(self, time)
+    local dict = self.dict
+    local cdata = self.cdata
+    local key_id = tonumber(cdata.key_id)
+    if key_id <= 0 then
+        return nil, "unlocked"
+    end
+
+    if not time then
+        time = self.exptime
+    end
+
+    local ok, err =  dict:replace(self.key, true, time)
+    if not ok then
+        return nil, err
+    end
 
     return 1
 end

--- a/lib/resty/lock.lua
+++ b/lib/resty/lock.lua
@@ -212,7 +212,7 @@ function _M.expire(self, time)
         return nil, err
     end
 
-    return 1
+    return true
 end
 
 

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -510,15 +510,15 @@ lock 2: unlock: nil, unlocked
 GET /t
 --- response_body
 lock 1: lock: 0, nil
-lock 1: expire: 1, nil
+lock 1: expire: true, nil
 lock 2: lock: nil, timeout
-lock 1: expire: 1, nil
+lock 1: expire: true, nil
 lock 2: lock: nil, timeout
 lock 1: unlock: 1, nil
 lock 1: lock: 0, nil
-lock 1: expire: 1, nil
+lock 1: expire: true, nil
 lock 2: lock: nil, timeout
-lock 1: expire: 1, nil
+lock 1: expire: true, nil
 lock 2: lock: nil, timeout
 lock 1: unlock: 1, nil
 

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -468,3 +468,59 @@ lock 2: unlock: nil, unlocked
 --- no_error_log
 [error]
 
+
+
+=== TEST 13: expire()
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local lock = require "resty.lock"
+            for i = 1, 2 do
+                local lock1 = lock:new("cache_locks", { timeout = 0, exptime = 0.1 })
+                local lock2 = lock:new("cache_locks", { timeout = 0, exptime = 0.1 })
+
+                local elapsed, err = lock1:lock("foo")
+                ngx.say("lock 1: lock: ", elapsed, ", ", err)
+
+                ngx.sleep(0.06)
+
+                local exp, err = lock1:expire()
+                ngx.say("lock 1: expire: ", exp, ", ", err)
+
+                ngx.sleep(0.06)
+
+                local elapsed, err = lock2:lock("foo")
+                ngx.say("lock 2: lock: ", elapsed, ", ", err)
+
+                local exp, err = lock1:expire(0.2)
+                ngx.say("lock 1: expire: ", exp, ", ", err)
+
+                ngx.sleep(0.15)
+
+                local elapsed, err = lock2:lock("foo")
+                ngx.say("lock 2: lock: ", elapsed, ", ", err)
+
+                local ok, err = lock1:unlock()
+                ngx.say("lock 1: unlock: ", ok, ", ", err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+lock 1: lock: 0, nil
+lock 1: expire: 1, nil
+lock 2: lock: nil, timeout
+lock 1: expire: 1, nil
+lock 2: lock: nil, timeout
+lock 1: unlock: 1, nil
+lock 1: lock: 0, nil
+lock 1: expire: 1, nil
+lock 2: lock: nil, timeout
+lock 1: expire: 1, nil
+lock 2: lock: nil, timeout
+lock 1: unlock: 1, nil
+
+--- no_error_log
+[error]

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -480,6 +480,9 @@ lock 2: unlock: nil, unlocked
                 local lock1 = lock:new("cache_locks", { timeout = 0, exptime = 0.1 })
                 local lock2 = lock:new("cache_locks", { timeout = 0, exptime = 0.1 })
 
+                local exp, err = lock1:expire()
+                ngx.say("lock 1: expire: ", exp, ", ", err)
+
                 local elapsed, err = lock1:lock("foo")
                 ngx.say("lock 1: lock: ", elapsed, ", ", err)
 
@@ -501,26 +504,40 @@ lock 2: unlock: nil, unlocked
                 local elapsed, err = lock2:lock("foo")
                 ngx.say("lock 2: lock: ", elapsed, ", ", err)
 
-                local ok, err = lock1:unlock()
-                ngx.say("lock 1: unlock: ", ok, ", ", err)
+                ngx.sleep(0.1)
+
+                local elapsed, err = lock2:lock("foo")
+                ngx.say("lock 2: lock: ", elapsed, ", ", err)
+
+                local ok, err = lock2:unlock()
+                ngx.say("lock 2: unlock: ", ok, ", ", err)
+
+                local exp, err = lock2:expire(0.2)
+                ngx.say("lock 2: expire: ", exp, ", ", err)
             end
         }
     }
 --- request
 GET /t
 --- response_body
+lock 1: expire: nil, unlocked
 lock 1: lock: 0, nil
 lock 1: expire: true, nil
 lock 2: lock: nil, timeout
 lock 1: expire: true, nil
 lock 2: lock: nil, timeout
-lock 1: unlock: 1, nil
+lock 2: lock: 0, nil
+lock 2: unlock: 1, nil
+lock 2: expire: nil, unlocked
+lock 1: expire: nil, unlocked
 lock 1: lock: 0, nil
 lock 1: expire: true, nil
 lock 2: lock: nil, timeout
 lock 1: expire: true, nil
 lock 2: lock: nil, timeout
-lock 1: unlock: 1, nil
+lock 2: lock: 0, nil
+lock 2: unlock: 1, nil
+lock 2: expire: nil, unlocked
 
 --- no_error_log
 [error]


### PR DESCRIPTION
is being held.

It is useful, say if you need to perform some task exclusively until certain conditions are met. Since you may not know how much steps there will be, you can use `expire()` to refresh the lock during each step.