### PR TITLE
optimize: return setmetatable is NYI that can not be jit compiled.

### DIFF
--- a/lib/resty/lock.lua
+++ b/lib/resty/lock.lua
@@ -119,7 +119,8 @@ function _M.new(_, dict_name, opts)
         ratio = ratio or 2,
         max_step = max_step or 0.5,
     }
-    return setmetatable(self, mt)
+    setmetatable(self, mt)
+    return self
 end
 
 


### PR DESCRIPTION
---- TRACE 162 abort setmetatable -- NYI: return to lower frame