### PR TITLE
Correct package status in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@ Table of Contents
 Status
 ======
 
-This library is still under early development and is production ready.
+This library is production ready.
 
 Synopsis
 ========


### PR DESCRIPTION
Current package status seems misleading a little - when I read "early development" and "production ready" in the same sentence, I tend to suspect there is an error somewhere. Actually seems like this package is mature enough so "early development" can be safely removed:)